### PR TITLE
Fix typo in rich text prompt

### DIFF
--- a/app.py
+++ b/app.py
@@ -190,7 +190,7 @@ def run_app():
             pla_path_input = Prompt.ask("[bold green]Enter path to the PLA submissions[/bold green]", console=console)
             sla_path_input = Prompt.ask("[bold green]Enter path to the SLA submissions[/bold green]", console=console)
             fsrn_path_input = Prompt.ask("[bold green]Enter path to the FSRN submissions[/bold green]", console=console)
-            cta_path_input = Prompt.ask("[bold green]Enter path to the CTA submissions/bold green]", console=console)
+            cta_path_input = Prompt.ask("[bold green]Enter path to the CTA submissions[/bold green]", console=console)
 
             results = handle_generate_batch_import(imu_dashboard_path_input, pla_path_input, sla_path_input,
                                                    fsrn_path_input,


### PR DESCRIPTION
The closing tag for the rich text prompt was missing a bracket, causing it to render incorrectly.